### PR TITLE
[info] User Deprecated: The "Okvpn\Bundle\CronBundle\Loader\ScheduleLoader::getSchedules()" method will require a new "array $options." argument in the next major version of its interface "Okvpn\Bundle\CronBundle\Loader\ScheduleLoaderInterface", not defining it is deprecated

### DIFF
--- a/src/Loader/ScheduleLoaderInterface.php
+++ b/src/Loader/ScheduleLoaderInterface.php
@@ -9,7 +9,7 @@ use Okvpn\Bundle\CronBundle\Model\ScheduleEnvelope;
 interface ScheduleLoaderInterface
 {
     /**
-     * @param array $options. Any options, like group.
+     * @param array $options Any options, like group.
      *
      * @return iterable|ScheduleEnvelope[]
      */


### PR DESCRIPTION
Issue: https://github.com/vtsykun/cron-bundle/issues/4

