### PR TITLE
Fix InvalidArgumentException caused in CommandRunnerEngine

### DIFF
--- a/src/Middleware/CommandRunnerEngine.php
+++ b/src/Middleware/CommandRunnerEngine.php
@@ -35,7 +35,7 @@ final class CommandRunnerEngine implements MiddlewareEngineInterface
             $commandArguments = $envelope->get(ArgumentsStamp::class) ?
                 $envelope->get(ArgumentsStamp::class)->getArguments() : [];
 
-            $input = new ArrayInput(array_merge(['command' => $handler->getName()], $commandArguments));
+            $input = new ArrayInput($commandArguments);
 
             $output = new BufferedOutput();
             $handler->run($input, $output);


### PR DESCRIPTION
Fixes: The "command" argument does not exist.

```
root@7f1f6f3b669c:/app# bin/console okvpn:debug:cron --execute-one 0 -vvv
 > Scheduling run for command App\Command\CancelFailedImportsCommand ...
[info] > Run schedule task App\Command\CancelFailedImportsCommand

In ArrayInput.php line 191:

  [Symfony\Component\Console\Exception\InvalidArgumentException]
  The "command" argument does not exist.


Exception trace:
  at /app/vendor/symfony/console/Input/ArrayInput.php:191
 Symfony\Component\Console\Input\ArrayInput->addArgument() at /app/vendor/symfony/console/Input/ArrayInput.php:130
 Symfony\Component\Console\Input\ArrayInput->parse() at /app/vendor/symfony/console/Input/Input.php:55
 Symfony\Component\Console\Input\Input->bind() at /app/vendor/symfony/console/Command/Command.php:285
 Symfony\Component\Console\Command\Command->run() at /app/vendor/okvpn/cron-bundle/src/Middleware/CommandRunnerEngine.php:42
 Okvpn\Bundle\CronBundle\Middleware\CommandRunnerEngine->handle() at /app/vendor/okvpn/cron-bundle/src/Middleware/LockMiddlewareEngine.php:28
 Okvpn\Bundle\CronBundle\Middleware\LockMiddlewareEngine->handle() at /app/vendor/okvpn/cron-bundle/src/Middleware/AsyncProcessEngine.php:29
 Okvpn\Bundle\CronBundle\Middleware\AsyncProcessEngine->handle() at /app/vendor/okvpn/cron-bundle/src/Middleware/CronMiddlewareEngine.php:33
 Okvpn\Bundle\CronBundle\Middleware\CronMiddlewareEngine->handle() at /app/vendor/okvpn/cron-bundle/src/Runner/ScheduleRunner.php:41
 Okvpn\Bundle\CronBundle\Runner\ScheduleRunner->execute() at /app/vendor/okvpn/cron-bundle/src/Command/CronDebugCommand.php:82
 Okvpn\Bundle\CronBundle\Command\CronDebugCommand->execute() at /app/vendor/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at /app/vendor/symfony/console/Application.php:1081
 Symfony\Component\Console\Application->doRunCommand() at /app/vendor/symfony/framework-bundle/Console/Application.php:91
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /app/vendor/symfony/console/Application.php:320
 Symfony\Component\Console\Application->doRun() at /app/vendor/symfony/framework-bundle/Console/Application.php:80
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /app/vendor/symfony/console/Application.php:174
 Symfony\Component\Console\Application->run() at /app/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php:54
 Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner->run() at /app/vendor/autoload_runtime.php:29
 require_once() at /app/bin/console:11
```