### PR TITLE
Add messenger option to AsCron attribute

### DIFF
--- a/src/Attribute/AsCron.php
+++ b/src/Attribute/AsCron.php
@@ -11,18 +11,21 @@ final class AsCron
     public $lock;
     public $async;
     public $options;
+    public $messenger;
 
     public function __construct(
         string $cron,
         bool $lock = null,
         bool $async = null,
         array $options = [],
+        bool $messenger = null
     ) {
         // Replace when update PHP > 7.2
         $this->async = $async;
         $this->lock = $lock;
         $this->cron = $cron;
         $this->options = $options;
+        $this->messenger = $messenger;
     }
 
     public function getAttributes(): array


### PR DESCRIPTION
Adds a `messenger` option to the `AsCron` attribute, this is a "lazy shorthand" and brings the following value:

You can use

```
#[AsCron('*/5 * * * *', messenger: true)]
```

instead of:

```
#[AsCron('*/5 * * * *', options: ["messenger" => true])]
```